### PR TITLE
Set hidden page variable field to current page

### DIFF
--- a/lib/pagem.rb
+++ b/lib/pagem.rb
@@ -66,7 +66,7 @@ class Pagem
                     pager_section(p, tp),
                     icon_link('angle-right', I18n.t('application.pagination.next', :default => "Next"), href, link_options(p + 1, p < tp)),
                     icon_link('angle-double-right', I18n.t('application.pagination.last', :default => "Last"), href, link_options(tp, p < tp)),
-                    hidden_field_tag(@page_variable, "")]),
+                    hidden_field_tag(@page_variable, current_page)]),
           class: 'controls'),
        {:class => 'paginate clearfix', :name => @page_variable})
     else


### PR DESCRIPTION
Set hidden page variable to current page number so submitted form has the data vs an empty string.

Fixes Balance features/inventory/shipments/manual_create/container_pagination.feature:305:447 on the UI_Updates branch.

@bzuniga-mdsol @mpolun-mdsol @rkichenama 